### PR TITLE
bacon: make config_bt_addr service oneshot again

### DIFF
--- a/rootdir/etc/init.bacon.rc
+++ b/rootdir/etc/init.bacon.rc
@@ -413,6 +413,7 @@ service config_bt_addr /system/bin/btnvtool -O
     class core
     user bluetooth
     group bluetooth radio
+    oneshot
 
 service hciattach /system/bin/sh /system/etc/init.qcom.bt.sh
     class late_start


### PR DESCRIPTION
i.e.: Do not restart the service when it exits otherwise we get
oodles of spam in kernel log:

[ 3288.793409,0] init: Starting service 'config_bt_addr'...
[ 3288.846610,0] init: Service 'config_bt_addr' (pid 27497) exited with
status 0
[ 3288.846647,0] init: Service 'config_bt_addr' (pid 27497) killing any
children in process group
[ 3293.851178,0] init: Starting service 'config_bt_addr'...

Change-Id: I99dac4db8b13e556030f79a57a105b9429bf9ab5