### PR TITLE
bacon: Grant rmt_storage proper unix perms

### DIFF
--- a/rootdir/etc/init.bacon.rc
+++ b/rootdir/etc/init.bacon.rc
@@ -282,7 +282,7 @@ on post-fs-data
 service rmt_storage /system/bin/rmt_storage
     class core
     user root
-    group system
+    group system wakelock
 
 service rfs_access /system/bin/rfs_access
     class core

--- a/sepolicy/rmt_storage.te
+++ b/sepolicy/rmt_storage.te
@@ -1,3 +1,2 @@
 # Allow rmt_storage to backup/restore NV contents
 allow rmt_storage nvbackup_block_device:blk_file rw_file_perms;
-allow rmt_storage self:capability dac_override;


### PR DESCRIPTION
Do not grant DAC override permission which would allow this daemon
unix permissions to everything.

avc: denied { dac_override } for pid=2664 comm="rmt_storage" capability=1 scontext=u:r:rmt_storage:s0 tcontext=u:r:rmt_storage:s0 tclass=capability permissive=0

Add wakelock group to access:
/sys/power/wake_lock
-rw-rw----  1 radio  wakelock 4096 2017-06-28 00:37 wake_unlock

Change-Id: Ib02b4aedab479f5ad8aca3a2100b5c489397002a