### PR TITLE
Revert "bacon: enable sdcardFS"

### DIFF
--- a/system.prop
+++ b/system.prop
@@ -67,9 +67,6 @@ ro.use_data_netmgrd=true
 
 telephony.lteOnGsmDevice=1
 
-# SdcardFS
-ro.sys.sdcardfs=true
-
 # Sensors
 ro.qc.sdk.camera.facialproc=true
 ro.qc.sdk.gestures.camera=false


### PR DESCRIPTION
There is evidence that this branch of sdcardfs can cause kernel
panics. We are working on 15.1 mainly and 14.1 is in maintenance mode,
so disable the offending feature for now.

This reverts commit 1db9ade0adb5df3786a17efb8a8665c0add59fa3.

Change-Id: Ic9841a636cb0e0733c06594424bb31679fca9716